### PR TITLE
Bind "prediction.py" to /prediction

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -11,7 +11,7 @@ def status():
     return jsonify({'status': 'ok'})
 
 
-@application.route('/predictions', methods=['POST'])
+@application.route('/prediction', methods=['POST'])
 def create_prediction():
     data = request.data or '{}'
     body = json.loads(data)


### PR DESCRIPTION
## Description

README and QuickStart are referring to /prediction, not /predictions

https://github.com/opendatahub-io/odh-s2i-project-simple/blob/8a05dc1f1fa707b8b6a4d3476e1efa7e5f7ee3fb/README.md?plain=1#L106
https://github.com/opendatahub-io/odh-manifests/blob/78085dd5e4e58b1b9ce66705894cbb0c0bbf1f8c/odh-dashboard/apps/jupyter/deploy-python-model-quickstart.yaml#L72

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
